### PR TITLE
Feat/prevent driver uninstall ios

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -19,17 +19,7 @@
 
 package maestro.cli
 
-import maestro.cli.command.BugReportCommand
-import maestro.cli.command.CloudCommand
-import maestro.cli.command.DownloadSamplesCommand
-import maestro.cli.command.LoginCommand
-import maestro.cli.command.LogoutCommand
-import maestro.cli.command.PrintHierarchyCommand
-import maestro.cli.command.QueryCommand
-import maestro.cli.command.RecordCommand
-import maestro.cli.command.StudioCommand
-import maestro.cli.command.TestCommand
-import maestro.cli.command.UploadCommand
+import maestro.cli.command.*
 import maestro.cli.report.TestDebugReporter
 import maestro.cli.update.Updates
 import maestro.cli.util.ErrorReporter
@@ -58,6 +48,7 @@ import kotlin.system.exitProcess
         LogoutCommand::class,
         BugReportCommand::class,
         StudioCommand::class,
+        InitDriverCommand::class,
     ]
 )
 class App {

--- a/maestro-cli/src/main/java/maestro/cli/command/InitDriverCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/InitDriverCommand.kt
@@ -1,0 +1,51 @@
+/*
+ *
+ *  Copyright (c) 2022 mobile.dev inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package maestro.cli.command
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import maestro.cli.App
+import maestro.cli.DisableAnsiMixin
+import maestro.cli.session.MaestroSessionManager
+import maestro.cli.view.green
+import picocli.CommandLine
+import xcuitest.installer.XCTestInstaller
+
+@CommandLine.Command(
+    name = "initDriver",
+    description = [
+        "init the driver"
+    ],
+    hidden = true
+)
+class InitDriverCommand : Runnable {
+
+    @CommandLine.Mixin
+    var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.ParentCommand
+    private val parent: App? = null
+
+    override fun run() {
+        MaestroSessionManager.newSession(parent?.host, parent?.port, parent?.deviceId) {
+            XCTestInstaller.shouldKeepDriver = true
+        }
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -37,6 +37,7 @@ import okio.buffer
 import okio.sink
 import picocli.CommandLine
 import picocli.CommandLine.Option
+import xcuitest.installer.XCTestInstaller
 import java.io.File
 import java.util.concurrent.Callable
 import kotlin.io.path.absolutePathString
@@ -93,6 +94,12 @@ class TestCommand : Callable<Int> {
     )
     private var excludeTags: List<String> = emptyList()
 
+    @Option(
+        names = ["--skipDriverSetup"],
+        description = ["Prevent the install and uninstall of the maestro driver"]
+    )
+    private var skipDriverSetup = false
+
     @CommandLine.Spec
     lateinit var commandSpec: CommandLine.Model.CommandSpec
 
@@ -122,6 +129,9 @@ class TestCommand : Callable<Int> {
             else parent?.deviceId
 
         env = env.withInjectedShellEnvVars()
+
+        XCTestInstaller.shouldUseAlreadyInstalledDriver = skipDriverSetup
+        XCTestInstaller.shouldKeepDriver = skipDriverSetup
         
         return MaestroSessionManager.newSession(parent?.host, parent?.port, deviceId) { session ->
             val maestro = session.maestro

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -34,7 +34,7 @@ class LocalXCTestInstaller(
     private val port = defaultPort ?: SocketUtils.nextFreePort(9800, 9900)
 
     override fun uninstall() {
-        if (useXcodeTestRunner) {
+        if (useXcodeTestRunner || XCTestInstaller.shouldKeepDriver) {
             return
         }
 

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -61,6 +61,14 @@ class LocalXCTestInstaller(
     }
 
     override fun start(): XCTestClient? {
+        if(XCTestInstaller.shouldUseAlreadyInstalledDriver) {
+            repeat(3) {
+                if (ensureOpen()) {
+                    return XCTestClient(host, port)
+                }
+            }
+            throw IllegalStateException("Driver is not installed, run initDriver or don't use --skipDriverSetup")
+        }
         if (useXcodeTestRunner) {
             repeat(20) {
                 if (ensureOpen()) {

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/XCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/XCTestInstaller.kt
@@ -11,5 +11,6 @@ interface XCTestInstaller: AutoCloseable {
 
     companion object {
         var shouldKeepDriver: Boolean = false
+        var shouldUseAlreadyInstalledDriver: Boolean = false
     }
 }

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/XCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/XCTestInstaller.kt
@@ -8,4 +8,8 @@ interface XCTestInstaller: AutoCloseable {
     fun uninstall()
 
     fun isChannelAlive(): Boolean
+
+    companion object {
+        var shouldKeepDriver: Boolean = false
+    }
 }


### PR DESCRIPTION
## Proposed Changes
Create a new command `initDriver` that installs the maestro driver.
Added an option `--skipDriverSetup` to the `test`command that prevent the installation and uninstallation of the driver at the beginning and the end of a test.
